### PR TITLE
Fix to compile with rust nightly

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -56,6 +56,7 @@ fn write_toc(book: &Book, path_to_root: &Path, out: &mut Writer) -> IoResult<()>
 
 fn render(book: &Book, tgt: &Path) -> CliResult<()> {
     let tmp = TempDir::new("rust-book")
+                      .ok()
                       .expect("could not create temporary directory"); // FIXME: lift to Result instead
 
     for (section, item) in book.iter() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::fmt::{Show, Formatter};
 
 use std::io::IoError;
 
-pub type CliError = Box<Error>;
+pub type CliError = Box<Error + 'static>;
 pub type CliResult<T> = Result<T, CliError>;
 
 pub trait Error {
@@ -19,14 +19,14 @@ pub trait FromError<E> {
     fn from_err(err: E) -> Self;
 }
 
-impl Show for Box<Error> {
+impl Show for Box<Error + 'static> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
     }
 }
 
-impl<E: Error + 'static> FromError<E> for Box<Error> {
-    fn from_err(err: E) -> Box<Error> {
+impl<E: Error + 'static> FromError<E> for Box<Error + 'static> {
+    fn from_err(err: E) -> Box<Error + 'static> {
         box err as Box<Error>
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -6,8 +6,8 @@ use std::io::IoResult;
 
 pub struct Term {
     verbose: bool,
-    out: Box<Writer>,
-    err: Box<Writer>
+    out: Box<Writer + 'static>,
+    err: Box<Writer + 'static>
 }
 
 impl Term {


### PR DESCRIPTION
- Sprinkle `'static` on `Box`es
- `Result.expect()` -> `Result.ok().expect()`

Tested with `rustc 0.13.0-dev (e4761c85b 2014-10-15 09:57:18 +0000)`
