### PR TITLE
Use protocol relative URLs in CSS

### DIFF
--- a/src/css.rs
+++ b/src/css.rs
@@ -1,7 +1,7 @@
 // The rust-book CSS in string form.
 
 pub static STYLE: &'static str = r#"
-@import url("http://static.rust-lang.org/doc/master/rust.css");
+@import url("//static.rust-lang.org/doc/master/rust.css");
 
 body {
     max-width:none;


### PR DESCRIPTION
this was a change via githubs web interface, but this should work.

closes rust-lang/rust-guidelines/issues/34
