### PR TITLE
Remove `convert` feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@
 #![feature(rustdoc)]
 #![feature(rustc_private)]
 #![feature(path_relative_from)]
-#![feature(convert)]
 
 extern crate rustdoc;
 extern crate rustc_back;


### PR DESCRIPTION
Fixes the build with the latest Rust nightly.