### PR TITLE
Explicitly allow 'dead' code from UI

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -27,8 +27,10 @@ use javascript;
 
 use rustdoc;
 
+#[allow(dead_code)]
 struct Build;
 
+#[allow(dead_code)]
 pub fn parse_cmd(name: &str) -> Option<Box<Subcommand>> {
     if name == "build" {
         Some(Box::new(Build))

--- a/src/help.rs
+++ b/src/help.rs
@@ -15,8 +15,10 @@ use error::CliResult;
 use error::CommandResult;
 use term::Term;
 
+#[allow(dead_code)]
 struct Help;
 
+#[allow(dead_code)]
 pub fn parse_cmd(name: &str) -> Option<Box<Subcommand>> {
     match name {
         "help" | "--help" | "-h" | "-?" => Some(Box::new(Help)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,10 @@
 extern crate rustdoc;
 extern crate rustc_back;
 
-use std::env;
-use std::error::Error;
-use subcommand::Subcommand;
-use term::Term;
+#[cfg(not(test))] use std::env;
+#[cfg(not(test))] use std::error::Error;
+#[cfg(not(test))] use subcommand::Subcommand;
+#[cfg(not(test))] use term::Term;
 
 mod term;
 mod error;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -15,8 +15,10 @@ use error::CliResult;
 use error::CommandResult;
 use term::Term;
 
+#[allow(dead_code)]
 struct Serve;
 
+#[allow(dead_code)]
 pub fn parse_cmd(name: &str) -> Option<Box<Subcommand>> {
     if name == "serve" {
         Some(Box::new(Serve))

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -31,6 +31,7 @@ pub trait Subcommand {
 }
 
 /// Create a Subcommand object based on its name.
+#[allow(dead_code)]
 pub fn parse_name(name: &str) -> Option<Box<Subcommand>> {
     let cmds: [fn(&str) -> Option<Box<Subcommand>>; 4] = [help::parse_cmd,
                                                           build::parse_cmd,

--- a/src/term.rs
+++ b/src/term.rs
@@ -20,6 +20,7 @@ pub struct Term {
 }
 
 impl Term {
+    #[allow(dead_code)]
     pub fn new() -> Term {
         Term {
             err: Box::new(io::stderr())

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,8 +19,10 @@ use std::fs::File;
 use std::env;
 use std::process::Command;
 
+#[allow(dead_code)]
 struct Test;
 
+#[allow(dead_code)]
 pub fn parse_cmd(name: &str) -> Option<Box<Subcommand>> {
     if name == "test" {
         Some(Box::new(Test))


### PR DESCRIPTION
I figured out why the build was breaking - there's a lot of command-line UI code that's only called from the `main()` function, which was disabled in test mode. Normally, this would just raise warnings, but since you have `#![deny(warnings)]` enabled, this causes compiler errors instead. Thus, the build breaks.

Since I figured you probably wanted to leave on `deny(warnings)`, I just went ahead and disabled the `dead_code` and `unused_imports` lints for all of the argument parsing code. They're only explicitly disabled for the UI stuff, so the lints are still on for everything else. 

If you'd rather not do this, reflowing compiler warnings would also fix the build, as would adding `#[cfg(not(test))]` to everything related to argument parsing. I figured this was the quickest and most reasonable fix.