### PR TITLE
Bring playpen.js up to date with @rust-lang/rust@be203ac25836

### DIFF
--- a/librustdoc/html/static/playpen.js
+++ b/librustdoc/html/static/playpen.js
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,17 +11,46 @@
 /*jslint browser: true, es5: true */
 /*globals $: true, rootPath: true */
 
-(function() {
-    if (window.playgroundUrl) {
-        $('pre.rust').hover(function() {
-            var a = $('<a>').text('⇱').attr('class', 'test-arrow');
-            var code = $(this).prev(".rusttest").text();
-            a.attr('href', window.playgroundUrl + '?code=' +
-                           encodeURIComponent(code));
-            a.attr('target', '_blank');
-            $(this).append(a);
-        }, function() {
-            $(this).find('a.test-arrow').remove();
-        });
+document.addEventListener('DOMContentLoaded', function() {
+    'use strict';
+
+    if (!window.playgroundUrl) {
+        return;
     }
-}());
+
+    var featureRegexp = new RegExp('^\s*#!\\[feature\\(\.*?\\)\\]');
+    var elements = document.querySelectorAll('pre.rust-example-rendered');
+
+    Array.prototype.forEach.call(elements, function(el) {
+        el.onmouseover = function(e) {
+            if (el.contains(e.relatedTarget)) {
+                return;
+            }
+
+            var a = document.createElement('a');
+            a.setAttribute('class', 'test-arrow');
+            a.textContent = 'Run';
+
+            var code = el.previousElementSibling.textContent;
+
+            var channel = '';
+            if (featureRegexp.test(code)) {
+                channel = '&version=nightly';
+            }
+
+            a.setAttribute('href', window.playgroundUrl + '?code=' +
+                           encodeURIComponent(code) + channel);
+            a.setAttribute('target', '_blank');
+
+            el.appendChild(a);
+        };
+
+        el.onmouseout = function(e) {
+            if (el.contains(e.relatedTarget)) {
+                return;
+            }
+
+            el.removeChild(el.querySelectorAll('a.test-arrow')[0]);
+        };
+    });
+});


### PR DESCRIPTION
I realized Rust code blocks on the generated HTML book do not have the "Run" button. This was because librustdoc/html/static/playpen.js of this crate is not updated for a while.

I copied the latest playpen.js ([rust-lang/rust/src/librustdoc/html/static/playpen.js @ be203ac25836](https://github.com/rust-lang/rust/blob/be203ac25836/src/librustdoc/html/static/playpen.js)) and verified this solved the problem.

Thanks!